### PR TITLE
Revert "Bump kapicorp/kapitan from 0.33.0 to 0.33.1"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM kapicorp/kapitan:0.33.1
+FROM kapicorp/kapitan:0.33.0
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
Reverts quortex/kapitan-dockerfile#26

This Kapitan update causes a very significant explosion in inventory and compilation times.