### PR TITLE
Revert "Bump kapicorp/kapitan from 0.34.0 to 0.34.1"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM kapicorp/kapitan:0.34.1
+FROM kapicorp/kapitan:0.34.0
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
Kapitan is slower than before, reverting until issue is found. 