### PR TITLE
Revert "Bump kapicorp/kapitan from 0.34.0 to 0.34.2"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM kapicorp/kapitan:0.34.2
+FROM kapicorp/kapitan:0.34.0
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
Reverts quortex/kapitan-dockerfile#35 due to performance issues with go upgrade in 0.34.1